### PR TITLE
Clarify the caveat of the missing `hosts` key from features

### DIFF
--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -888,8 +888,10 @@ Return a list of features and services supported by the server.
   * *hosts*
 
     A dictionary, keyed by host name, that this server can be reached
-    at.  Normally this will only have a single entry; other entries
-    can be used in case there are other connection routes (e.g. Tor).
+    at.  If this dictionary is missing, then other servers will not peer
+    with this server.  Normally this dictionary will only have a single 
+    entry; other entries can be used in case there are other connection 
+    routes (e.g. Tor).
 
     The value for a host is itself a dictionary, with the following
     optional keys:


### PR DESCRIPTION
Added language to explain that if the hosts key is missing, other servers will not peer with the server.

Both ElectrumX/ElectronX and Fulcrum require this key to exist otherwise they will not peer with the server.

Stated another way: The absence of this key is an indication that the server does not wish to peer.

So, I added language to clarify that to the spec.
