### PR TITLE
"coin units" -> "satoshis"

### DIFF
--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -275,15 +275,15 @@ Return the confirmed and unconfirmed balances of a :ref:`script hash
 **Result**
 
   A dictionary with keys `confirmed` and `unconfirmed`.  The value of
-  each is the appropriate balance in coin units as a string.
+  each is the appropriate balance in satoshis as a string.
 
 **Result Example**
 
 ::
 
   {
-    "confirmed": "1.03873966",
-    "unconfirmed": "0.236844"
+    "confirmed": "103873966",
+    "unconfirmed": "236844"
   }
 
 blockchain.scripthash.get_history


### PR DESCRIPTION
Fix units used in `blockchain.scripthash.get_balance`