### PR TITLE
Added documentation for the resurrected blockchain.address.* methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = ElectrumX
+SPHINXPROJ    = electrum-cash-porotocol
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,5 @@
-Electrum Protocol
-=================
+Electrum Cash Protocol
+======================
 
 This is intended to be a reference for client and server authors
 alike.

--- a/protocol-changes.rst
+++ b/protocol-changes.rst
@@ -170,3 +170,16 @@ New methods
 Version 1.4.2
 =============
    * :func:`server.features` changed the requirement of key *hosts* from being MUST be present to RECOMMENDED. Note that ElectrumX will not peer with your server without this key.
+
+Version 1.4.3
+=============
+
+New methods
+-----------
+
+  * :func:`blockchain.address.get_balance` was brought back after having been removed in 1.3.
+  * :func:`blockchain.address.get_history` was brought back after having been removed in 1.3.
+  * :func:`blockchain.address.get_mempool` was brought back after having been removed in 1.3.
+  * :func:`blockchain.address.listunspent` was brought back after having been removed in 1.3.
+  * :func:`blockchain.address.subscribe` was brought back after having been removed in 1.3.
+  * :func:`blockchain.address.unsubscribe` to unsubscribe from an address.

--- a/protocol-changes.rst
+++ b/protocol-changes.rst
@@ -177,9 +177,16 @@ Version 1.4.3
 New methods
 -----------
 
-  * :func:`blockchain.address.get_balance` was brought back after having been removed in 1.3.
-  * :func:`blockchain.address.get_history` was brought back after having been removed in 1.3.
-  * :func:`blockchain.address.get_mempool` was brought back after having been removed in 1.3.
-  * :func:`blockchain.address.listunspent` was brought back after having been removed in 1.3.
-  * :func:`blockchain.address.subscribe` was brought back after having been removed in 1.3.
+  * :func:`blockchain.address.get_balance` was brought back after having been
+    removed in 1.3.
+  * :func:`blockchain.address.get_history` was brought back after having been
+    removed in 1.3.
+  * :func:`blockchain.address.get_mempool` was brought back after having been
+    removed in 1.3.
+  * :func:`blockchain.address.get_scripthash` to translate an address into a
+    script hash.
+  * :func:`blockchain.address.listunspent` was brought back after having been
+    removed in 1.3.
+  * :func:`blockchain.address.subscribe` was brought back after having been
+    removed in 1.3.
   * :func:`blockchain.address.unsubscribe` to unsubscribe from an address.

--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -14,8 +14,9 @@ Return the confirmed and unconfirmed balances of a Bitcoin Cash address.
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or as a Legacy
-    (base58) string.
+    The address as a Cash Address string (with or without prefix). Some server
+    implementations may also support Legacy (base58) addresses but are not
+    required to do so by this specification.
 
 **Result**
 
@@ -33,8 +34,9 @@ Return the confirmed and unconfirmed history of a Bitcoin Cash address.
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or as a Legacy
-    (base58) string.
+    The address as a Cash Address string (with or without prefix). Some server
+    implementations may also support Legacy (base58) addresses but are not
+    required to do so by this specification.
 
 **Result**
 
@@ -52,8 +54,9 @@ Return the unconfirmed transactions of a Bitcoin Cash address.
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or as a Legacy
-    (base58) string.
+    The address as a Cash Address string (with or without prefix). Some server
+    implementations may also support Legacy (base58) addresses but are not
+    required to do so by this specification.
 
 **Result**
 
@@ -74,8 +77,9 @@ them.
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or as a Legacy
-    (base58) string.
+    The address as a Cash Address string (with or without prefix). Some server
+    implementations may also support Legacy (base58) addresses but are not
+    required to do so by this specification.
 
 **Result**
 
@@ -94,8 +98,9 @@ Return an ordered list of UTXOs sent to a Bitcoin Cash address.
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or as a Legacy
-    (base58) string.
+    The address as a Cash Address string (with or without prefix). Some server
+    implementations may also support Legacy (base58) addresses but are not
+    required to do so by this specification.
 
 **Result**
 
@@ -113,8 +118,9 @@ Subscribe to a Bitcoin Cash address.
 
   *address*
 
-    The address as a Cash Address (with or without prefix) or as a Legacy
-    (base58) string.
+    The address as a Cash Address string (with or without prefix). Some server
+    implementations may also support Legacy (base58) addresses but are not
+    required to do so by this specification.
 
 **Result**
 
@@ -165,8 +171,9 @@ its :ref:`status <status>` changes.
 
   *address*
 
-    The address as a Cash Address (with or without prefix) or as a Legacy
-    (base58) string.
+    The address as a Cash Address string (with or without prefix). Some server
+    implementations may also support Legacy (base58) addresses but are not
+    required to do so by this specification.
 
 **Result**
 

--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -2,6 +2,149 @@
  Protocol Methods
 ==================
 
+blockchain.address.get_balance
+==============================
+
+Return the confirmed and unconfirmed balances of a Bitcoin Cash address.
+
+**Signature**
+
+  .. function:: blockchain.address.get_balance(address)
+  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+
+  * *address*
+
+    The address as a Cash Address (with or without prefix) or a Base58 string.
+
+**Result**
+
+  See :func:`blockchain.scripthash.get_balance`.
+
+blockchain.address.get_history
+==============================
+
+Return the confirmed and unconfirmed history of a Bitcoin Cash address.
+
+**Signature**
+
+  .. function:: blockchain.address.get_history(address)
+  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+
+  * *address*
+
+    The address as a Cash Address (with or without prefix) or a Base58 string.
+
+**Result**
+
+  As for :func:`blockchain.scripthash.get_history`.
+
+blockchain.address.get_mempool
+==============================
+
+Return the unconfirmed transactions of a Bitcoin Cash address.
+
+**Signature**
+
+  .. function:: blockchain.address.get_mempool(address)
+  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+
+  * *address*
+
+    The address as a Cash Address (with or without prefix) or a Base58 string.
+
+**Result**
+
+  As for :func:`blockchain.scripthash.get_mempool`.
+
+blockchain.address.listunspent
+==============================
+
+Return an ordered list of UTXOs sent to a Bitcoin Cash address.
+
+**Signature**
+
+  .. function:: blockchain.address.listunspent(address)
+  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+
+  * *address*
+
+    The address as a Cash Address (with or without prefix) or a Base58 string.
+
+**Result**
+
+  As for :func:`blockchain.scripthash.listunspent`.
+
+blockchain.address.subscribe
+============================
+
+Subscribe to a Bitcoin Cash address.
+
+**Signature**
+
+  .. function:: blockchain.address.subscribe(address)
+  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+
+  *address*
+
+    The address as a Cash Address (with or without prefix) or a Base58 string.
+
+**Result**
+
+  The :ref:`status <status>` of the address.
+
+**Notifications**
+
+  As this is a subcription, the client will receive a notification
+  when the :ref:`status <status>` of the address changes.  Its
+  signature is
+
+  .. function:: blockchain.address.subscribe(address, status)
+
+  .. note:: The address returned back to the client when notifying of status
+            changes will be in the same encoding and syle as was provided when
+            subscribing. In effect, a whitespace-stripped version of the address
+            string that the client provided will be sent back to the client when
+            notifying, in order to make it easier for clients to track the
+            notification.
+
+            It is unspecified what happens if a client subscribes to the same
+            address using multiple encodings or styles, but it is RECOMMENDED
+            that servers simply update their internal subscription tables on
+            subsequent subscriptions to the same destination such that they
+            honor the latest subscription only, and not subscribe clients
+            multiple times to the same logical destination. For example, Fulcrum
+            server will simply update its table for how to refer to the
+            subscription and send clients subsequent notifications using the
+            latest encoding style of that particular address that the client
+            last provided.
+
+            Similarly, if a client mixes `blockchain.address.*` and
+            `blockchain.scripthash.*` calls to the server, it is RECOMMENDED
+            that the server treat all addresses as equivalent to their
+            scripthashes internally such that it is possible to subscribe by
+            address and later unsubscribe by scripthash, for example.
+
+blockchain.address.unsubscribe
+=================================
+
+Unsubscribe from a Bitcoin Cash address, preventing future notifications if
+its :ref:`status <status>` changes.
+
+**Signature**
+
+  .. function:: blockchain.address.unsubscribe(address)
+  .. versionadded:: 1.4.3
+
+  *address*
+
+    The address as a Cash Address (with or without prefix) or a Base58 string.
+
+**Result**
+
+  Returns :const:`True` if the address was subscribed to, otherwise :const:`False`.
+  Note that :const:`False` might be returned even for something subscribed to earlier,
+  becuase the server can drop subscriptions in rare circumstances.
+
 blockchain.block.header
 =======================
 
@@ -889,11 +1032,11 @@ Return a list of features and services supported by the server.
 
     A dictionary, keyed by host name, that this server can be reached
     at.  If this dictionary is missing, then this is a way to signal to
-    other servers that while this host is reachable, it does not wish to 
-    peer with other servers.  A server SHOULD stop peering with a peer 
-    if it sees the *hosts* dictionary for its peer is empty and/or no  
-    longer contains the expected route (e.g. hostname).  Normally this 
-    dictionary will only contain a single entry; other entries can be 
+    other servers that while this host is reachable, it does not wish to
+    peer with other servers.  A server SHOULD stop peering with a peer
+    if it sees the *hosts* dictionary for its peer is empty and/or no
+    longer contains the expected route (e.g. hostname).  Normally this
+    dictionary will only contain a single entry; other entries can be
     used in case there are other connection routes (e.g. Tor).
 
     The value for a host is itself a dictionary, with the following
@@ -1016,8 +1159,8 @@ Only the first :func:`server.version` message is accepted.
 
 **Example**::
 
-  server.version("Electrum 3.0.6", ["1.1", "1.2"])
+  server.version("Electron Cash 3.3.6", ["1.2", "1.4"])
 
 **Example Result**::
 
-  ["ElectrumX 1.2.1", "1.2"]
+  ["Fulcrum 1.0.5", "1.4"]

--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -10,11 +10,12 @@ Return the confirmed and unconfirmed balances of a Bitcoin Cash address.
 **Signature**
 
   .. function:: blockchain.address.get_balance(address)
-  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+  .. versionadded:: 1.4.3
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or a Base58 string.
+    The address as a Cash Address (with or without prefix) or as a Legacy
+    (base58) string.
 
 **Result**
 
@@ -28,11 +29,12 @@ Return the confirmed and unconfirmed history of a Bitcoin Cash address.
 **Signature**
 
   .. function:: blockchain.address.get_history(address)
-  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+  .. versionadded:: 1.4.3
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or a Base58 string.
+    The address as a Cash Address (with or without prefix) or as a Legacy
+    (base58) string.
 
 **Result**
 
@@ -46,15 +48,39 @@ Return the unconfirmed transactions of a Bitcoin Cash address.
 **Signature**
 
   .. function:: blockchain.address.get_mempool(address)
-  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+  .. versionadded:: 1.4.3
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or a Base58 string.
+    The address as a Cash Address (with or without prefix) or as a Legacy
+    (base58) string.
 
 **Result**
 
   As for :func:`blockchain.scripthash.get_mempool`.
+
+blockchain.address.get_scripthash
+=================================
+
+Translate a Bitcoin Cash address to a :ref:`script hash <script hashes>`. This
+method is potentially useful for clients preferring to work with :ref:`script
+hashes <script hashes>` but lacking the local libraries necessary to generate
+them.
+
+**Signature**
+
+  .. function:: blockchain.address.get_scripthash(address)
+  .. versionadded:: 1.4.3
+
+  * *address*
+
+    The address as a Cash Address (with or without prefix) or as a Legacy
+    (base58) string.
+
+**Result**
+
+  The unique 32-byte hex-encoded :ref:`script hash <script hashes>` that
+  corresponds to the decoded address.
 
 blockchain.address.listunspent
 ==============================
@@ -64,11 +90,12 @@ Return an ordered list of UTXOs sent to a Bitcoin Cash address.
 **Signature**
 
   .. function:: blockchain.address.listunspent(address)
-  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+  .. versionadded:: 1.4.3
 
   * *address*
 
-    The address as a Cash Address (with or without prefix) or a Base58 string.
+    The address as a Cash Address (with or without prefix) or as a Legacy
+    (base58) string.
 
 **Result**
 
@@ -82,11 +109,12 @@ Subscribe to a Bitcoin Cash address.
 **Signature**
 
   .. function:: blockchain.address.subscribe(address)
-  .. deprecated:: 1.2 removed in version 1.3, re-added in version 1.4.3
+  .. versionadded:: 1.4.3
 
   *address*
 
-    The address as a Cash Address (with or without prefix) or a Base58 string.
+    The address as a Cash Address (with or without prefix) or as a Legacy
+    (base58) string.
 
 **Result**
 
@@ -137,13 +165,15 @@ its :ref:`status <status>` changes.
 
   *address*
 
-    The address as a Cash Address (with or without prefix) or a Base58 string.
+    The address as a Cash Address (with or without prefix) or as a Legacy
+    (base58) string.
 
 **Result**
 
-  Returns :const:`True` if the address was subscribed to, otherwise :const:`False`.
-  Note that :const:`False` might be returned even for something subscribed to earlier,
-  becuase the server can drop subscriptions in rare circumstances.
+  Returns :const:`True` if the address was subscribed to, otherwise
+  :const:`False`. Note that :const:`False` might be returned even for something
+  subscribed to earlier, because the server can drop subscriptions in rare
+  circumstances.
 
 blockchain.block.header
 =======================
@@ -363,7 +393,7 @@ Subscribe to receive block headers when a new block is found.
 
       See **Result** above.
 
-.. note:: should a new block arrive quickly, perhaps while the server
+.. note:: Should a new block arrive quickly, perhaps while the server
   is still processing prior blocks, the server may only notify of the
   most recent chain tip.  The protocol does not guarantee notification
   of all intermediate block headers.
@@ -635,9 +665,10 @@ Unsubscribe from a script hash, preventing future notifications if its :ref:`sta
 
 **Result**
 
-  Returns :const:`True` if the scripthash was subscribed to, otherwise :const:`False`.
-  Note that :const:`False` might be returned even for something subscribed to earlier,
-  becuase the server can drop subscriptions in rare circumstances.
+  Returns :const:`True` if the scripthash was subscribed to, otherwise
+  :const:`False`. Note that :const:`False` might be returned even for something
+  subscribed to earlier, because the server can drop subscriptions in rare
+  circumstances.
 
 blockchain.transaction.broadcast
 ================================

--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -1201,4 +1201,4 @@ Only the first :func:`server.version` message is accepted.
 
 **Example Result**::
 
-  ["Fulcrum 1.0.5", "1.4"]
+  ["AwesomeServer 2.2.3", "1.4"]

--- a/protocol-removed.rst
+++ b/protocol-removed.rst
@@ -40,6 +40,7 @@ Return the confirmed and unconfirmed balances of a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.get_balance(address)
+     :noindex:
   .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
@@ -58,6 +59,7 @@ Return the confirmed and unconfirmed history of a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.get_history(address)
+     :noindex:
   .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
@@ -76,6 +78,7 @@ Return the unconfirmed transactions of a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.get_mempool(address)
+     :noindex:
   .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
@@ -94,6 +97,7 @@ Return an ordered list of UTXOs sent to a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.listunspent(address)
+     :noindex:
   .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
@@ -112,6 +116,7 @@ Subscribe to a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.subscribe(address)
+     :noindex:
   .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   *address*
@@ -129,6 +134,7 @@ Subscribe to a bitcoin address.
   signature is
 
   .. function:: blockchain.address.subscribe(address, status)
+     :noindex:
 
 blockchain.headers.subscribe
 ============================

--- a/protocol-removed.rst
+++ b/protocol-removed.rst
@@ -40,7 +40,7 @@ Return the confirmed and unconfirmed balances of a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.get_balance(address)
-  .. deprecated:: 1.2 removed in version 1.3
+  .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
 
@@ -58,7 +58,7 @@ Return the confirmed and unconfirmed history of a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.get_history(address)
-  .. deprecated:: 1.2 removed in version 1.3
+  .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
 
@@ -76,7 +76,7 @@ Return the unconfirmed transactions of a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.get_mempool(address)
-  .. deprecated:: 1.2 removed in version 1.3
+  .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
 
@@ -94,7 +94,7 @@ Return an ordered list of UTXOs sent to a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.listunspent(address)
-  .. deprecated:: 1.2 removed in version 1.3
+  .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   * *address*
 
@@ -112,7 +112,7 @@ Subscribe to a bitcoin address.
 **Signature**
 
   .. function:: blockchain.address.subscribe(address)
-  .. deprecated:: 1.2 removed in version 1.3
+  .. deprecated:: 1.2 removed in version 1.3, *re-added in version 1.4.3*
 
   *address*
 


### PR DESCRIPTION
Hi @dagurval, as per our discussions I am documenting the resurrection of the `blockchain.address.*` methods.

I have this already implemented in my `dev` branch of Fulcrum and have tested it extensively.  A new version of Fulcrum 1.0.5 will be released soon that offers these resurrected methods.

I updated `protocol-changes`, `protocol-methods`, and `protocol-removed` to
reflect their new (old) documentation and their status as revived in
version 1.4.3 of the protocol.

Note I lack the tools on my system (and was a bit lazy, tbh) to actually run `make` to build the documentation. I did, however, use an online `rst` editor: https://livesphinx.herokuapp.com/. This editor seems good so I am optimistically hoping there are no render errors in my changes.

Would you mind also building these docs just to check?  In particular I added a **Note** box to `blockchain.address.subscribe`  which I feel needs double-checking that it renders right in the final built docs.

All apologies for not having the tools installed to build these docs -- I will figure it out but I just wanted this PR submitted today to get it out.
