### PR TITLE
Added ws_port and wss_port description to server.features

### DIFF
--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -1090,6 +1090,16 @@ Return a list of features and services supported by the server.
       An integer.  Omit or set to :const:`null` if TCP connectivity is
       not provided.
 
+    * *ws_port*
+
+      An integer.  Omit or set to :const:`null` if Web Socket (ws://)
+      connectivity is not provided.
+
+    * *wss_port*
+
+      An integer.  Omit or set to :const:`null` if Web Socket Secure (wss://)
+      connectivity is not provided.
+
     A server should ignore information provided about any host other
     than the one it connected to.
 


### PR DESCRIPTION
Hi,

I'm adding Web Sockets support to Fulcrum.  The are new optional entries in the `hosts` dict in `server.features` to advertise these Web Socket ports.  This is identical to how ElectrumX does it.  I updated the docs to reflect these optional keys.  