### PR TITLE
Corrected error in `get_balance`

### DIFF
--- a/protocol-methods.rst
+++ b/protocol-methods.rst
@@ -455,15 +455,15 @@ Return the confirmed and unconfirmed balances of a :ref:`script hash
 **Result**
 
   A dictionary with keys `confirmed` and `unconfirmed`.  The value of
-  each is the appropriate balance in satoshis as a string.
+  each is the appropriate balance in satoshis.
 
 **Result Example**
 
 ::
 
   {
-    "confirmed": "103873966",
-    "unconfirmed": "236844"
+    "confirmed": 103873966,
+    "unconfirmed": 236844
   }
 
 blockchain.scripthash.get_history


### PR DESCRIPTION
The result is as a number, not as a string. This is the case on all 3 servers: ElectrumX, Fulcrum, as well as Electrs.